### PR TITLE
Add more error handling for get_aws_metadata

### DIFF
--- a/lib/cwllog/env/aws.rb
+++ b/lib/cwllog/env/aws.rb
@@ -21,13 +21,18 @@ module CWLlog
         end
 
         def get_aws_metadata(category)
-          open(metadata_endpoint_base+category).read
+          open(metadata_endpoint_base+category, { :open_timeout => 2 }).read
         rescue OpenURI::HTTPError
+          nil
+        rescue Net::OpenTimeout
+          nil
+        rescue Errno::EHOSTUNREACH
           nil
         end
 
         def is_aws?
-          true if get_aws_metadata("").include?("ami-id")
+          data = get_aws_metadata("")
+          not data.nil? and data.include?("ami-id")
         rescue Errno::ECONNREFUSED
           false
         end


### PR DESCRIPTION
This is the first attempt to make cwl-log-generator applicable to computing resources other than AWS instances.

This request fixes the following issues:
- The current implementation of `get_aws_metadata` never timeout to access the metadata. This request adds a timeout to connect the metadata endpoint.
  - It also adds a rescue statement for `Net::OpenTimeout` to handle timeouts.
- I added a rescue statement for `Errno::EHOSTUNREACH` to handle the case that the host is not reachable to the metadata endpoint. Such a case will happen when we run cwl-log-generator on on-premise machines that are isolated from the internet.
- Fix `is_aws?` to handle the case of `get_aws_metadata("").nil?`

