### PR TITLE
Add disk/memory handling for MacOS

### DIFF
--- a/lib/cwllog/env.rb
+++ b/lib/cwllog/env.rb
@@ -28,11 +28,18 @@ module CWLlog
       end
 
       def get_total_memory
-        get_system_info("grep ^MemTotal /proc/meminfo | awk '{ print $2 }'")
+        case RUBY_PLATFORM
+        when /linux/
+          get_system_info("grep ^MemTotal /proc/meminfo | awk '{ print $2 }'")
+        when /darwin/
+          get_system_info("sysctl hw.memsize | awk '{ print $2 }'")
+        else
+          # unsupported
+        end
       end
 
       def get_disk_size
-        get_system_info("df -k --output=size / | awk 'NR==2 { print $1 }'")
+        get_system_info("df -k / | awk 'NR==2 { print $2 }'")
       end
     end
   end


### PR DESCRIPTION
This request fixes `get_total_memory` and `get_disk_size` to make them applicable to Mac resources.

- `/proc/meminfo` is not supported on Mac resources. I added the case for Mac by using `sysctl` command.
- Most linux systems use GNU df but MacOS uses BSD df and it does not support `--output` option. I removed `--output` option from `df` command and fix `awk` to fit the gap.