### PR TITLE
Move `platform` field from `workflow` to each step field

### DIFF
--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -25,7 +25,6 @@ module CWLlog
       parse_logs
       {
         workflow: {
-          platform: @@logs[:env],
           docker: @@logs[:docker][:info],
           start_date: @@logs[:cwl][:debug_info][:workflow][:start_date],
           end_date: @@logs[:cwl][:debug_info][:workflow][:end_date],
@@ -48,6 +47,7 @@ module CWLlog
         else
           steps[step_name] = step_info
         end
+        steps[step_name][:platform] = @@logs[:env]
       end
       steps
     end


### PR DESCRIPTION
This request moves `platform` to each step field.

Before:
```json
{
  "workflow": {
    "platform": {
      "hostname": "virgo",
      "total_memory": "17179869184",
      "disk_size": "976265452"
    },
    ...
  },
  "steps": {
    "cat": {
      ...
    },
    ...
  }
}
```

After:
```json
{
  "workflow": {
    ...
  },
  "steps": {
    "cat": {
      ...
      "platform": {
        "hostname": "virgo",
        "total_memory": "17179869184",
        "disk_size": "976265452"
      }
    },
    ...
  }
}
```

## Rationale
Some workflow engines such as Galaxy uses batch scheduler as a backend computing resource manager and thus some engines execute each step on the different computing resources.

This change will make us easier to use the same (or almost same) metadata format in various workflow engines.
