### PR TITLE
Change the type of memory size and disk size to integers

### DIFF
--- a/lib/cwllog/env.rb
+++ b/lib/cwllog/env.rb
@@ -36,16 +36,16 @@ module CWLlog
       def get_total_memory
         case RUBY_PLATFORM
         when /linux/
-          get_system_info("grep ^MemTotal /proc/meminfo | awk '{ print $2 }'")
+          get_system_info("grep ^MemTotal /proc/meminfo | awk '{ print $2 }'").to_i
         when /darwin/
-          get_system_info("sysctl hw.memsize | awk '{ print $2 }'")
+          get_system_info("sysctl hw.memsize | awk '{ print $2 }'").to_i
         else
           # unsupported
         end
       end
 
       def get_disk_size
-        get_system_info("df -k / | awk 'NR==2 { print $2 }'")
+        get_system_info("df -k / | awk 'NR==2 { print $2 }'").to_i
       end
     end
   end


### PR DESCRIPTION
This request changes the return type of `get_total_memory` and `get_disk_size` from string to integer.
It enables us to analyze metadata without converting field types.
