### PR TITLE
Move docker runtime information to each step field

### DIFF
--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -25,7 +25,6 @@ module CWLlog
       parse_logs
       {
         workflow: {
-          docker: @@logs[:docker][:info],
           start_date: @@logs[:cwl][:debug_info][:workflow][:start_date],
           end_date: @@logs[:cwl][:debug_info][:workflow][:end_date],
           cwl_file: @@logs[:cwl][:debug_info][:workflow][:cwlfile],
@@ -47,6 +46,7 @@ module CWLlog
         else
           steps[step_name] = step_info
         end
+        steps[step_name][:docker] = @@logs[:docker][:info]
         steps[step_name][:platform] = @@logs[:env]
       end
       steps


### PR DESCRIPTION
Similar to #3, it moves a docker runtime information such as docker version to each step field because they may have distinct values in general.
