### PR TITLE
Make consistent field names: rename `cwlfile` to `cwl_file`

### DIFF
--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -28,7 +28,7 @@ module CWLlog
           docker: @@logs[:docker][:info],
           start_date: @@logs[:cwl][:debug_info][:workflow][:start_date],
           end_date: @@logs[:cwl][:debug_info][:workflow][:end_date],
-          cwl_file: @@logs[:cwl][:debug_info][:workflow][:cwlfile],
+          cwl_file: @@logs[:cwl][:debug_info][:workflow][:cwl_file],
           genome_version: @@logs[:cwl][:debug_info][:workflow][:genome_version],
           input_jobfile: logs[:cwl][:input_jobfile],
         },

--- a/lib/cwllog/cwl/debuginfo.rb
+++ b/lib/cwllog/cwl/debuginfo.rb
@@ -40,7 +40,7 @@ module CWLlog
             workflow: {
               start_date: @@timestamps.first.strftime("%Y-%m-%d %H:%M:%S"),
               end_date: @@timestamps.last.strftime("%Y-%m-%d %H:%M:%S"),
-              cwlfile: get_cwlfile_name,
+              cwl_file: get_cwlfile_name,
               genome_version: get_genome_version,
             },
             steps: generate_step_info,
@@ -64,7 +64,7 @@ module CWLlog
           steps.each do |step|
             step_info[step] = {
               stepname: step,
-              cwlfile: get_tool_cwl_file_path(step),
+              cwl_file: get_tool_cwl_file_path(step),
               container_id: get_container_id(step),
               tool_status: get_tool_status(step),
               input_files: input_object(step),


### PR DESCRIPTION
In the current output format, there exist `cwlfile` field for steps and `cwl_file` field for workflow.
This request renames `cwlfile` to `cwl_file` to make consistent field names that hold a CWL file name.
