### PR TITLE
Add `start_date` and `end_date` for each step

### DIFF
--- a/lib/cwllog/cwl/debuginfo.rb
+++ b/lib/cwllog/cwl/debuginfo.rb
@@ -64,6 +64,8 @@ module CWLlog
           steps.each do |step|
             step_info[step] = {
               stepname: step,
+              start_date: get_start_date_for_step(step),
+              end_date: get_end_date_for_step(step),
               cwl_file: get_tool_cwl_file_path(step),
               container_id: get_container_id(step),
               tool_status: get_tool_status(step),
@@ -93,6 +95,16 @@ module CWLlog
           else
             "failed"
           end
+        end
+
+        def get_start_date_for_step(step_name)
+          start_regex = /^.+?\] \[step #{step_name}\] start/
+          parse_date_prefix(@@events.select{|str| str =~ start_regex }.first).strftime("%Y-%m-%d %H:%M:%S")
+        end
+
+        def get_end_date_for_step(step_name)
+          end_regex = /^.+?\] \[step #{step_name}\] completed success/
+          parse_date_prefix(@@events.select{|str| str =~ end_regex }.first).strftime("%Y-%m-%d %H:%M:%S")
         end
 
         def get_tool_cwl_file_path(step_name)


### PR DESCRIPTION
This request adds `start_date` and `end_date` for each step to make the structure more consistent with workflows and command line tools.

I added functions to parse `cwltool.log` instead of using `start_date` and `end_date` in `docker` field to make them applicable non-docker commands.
- To get `start_date`, `get_start_date_for_step` finds and parses the following type of line: `[2018-07-20 17:28:06] [step sort2] start`
- To get `end_date`, `get_end_date_for_step` finds and parses the lines like: `[2018-07-20 17:28:07] [step sort2] completed success`

Such a consistency makes us easier to investigate the metadata and also makes easier to extend cwl-log-generator in the future (e.g. extend it to nested workflows).

---
Note: In macOS environment, `start_date` and `end_date` for the step are not consistent with `start_date` and `end_date` in `docker_inspect` field. I guess the reason is that docker for Mac runs a virtual machine for docker and the time in the host and that in the virtual machine are not completely synchronized.

Here is an example of inconsistent dates:
```json
    "sort1": {
      "stepname": "sort1",
      "start_date": "2018-07-20 17:28:03",
      "end_date": "2018-07-20 17:28:05",
      ...
      "docker_inspect": {
        "start_time": "2018-07-20T08:28:21.2507618Z",
        "end_time": "2018-07-20T08:28:21.3152544Z", # later than `sort1.end_date`!?
        "exit_code": 0
      },
    },
   ...
```
