### PR TITLE
Unify the field names for input and output objects

### DIFF
--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -29,7 +29,7 @@ module CWLlog
           end_date: @@logs[:cwl][:debug_info][:workflow][:end_date],
           cwl_file: @@logs[:cwl][:debug_info][:workflow][:cwl_file],
           genome_version: @@logs[:cwl][:debug_info][:workflow][:genome_version],
-          input_jobfile: logs[:cwl][:input_jobfile],
+          inputs: logs[:cwl][:inputs],
         },
         steps: concat_steps_with_docker_ps,
       }

--- a/lib/cwllog/cwl.rb
+++ b/lib/cwllog/cwl.rb
@@ -7,7 +7,7 @@ module CWLlog
       def generate
         {
           debug_info: CWLlog::CWL::DebugInfo.generate,
-          input_jobfile: CWLlog::CWL::JobConf.generate,
+          inputs: CWLlog::CWL::JobConf.generate,
         }
       end
     end

--- a/lib/cwllog/cwl/debuginfo.rb
+++ b/lib/cwllog/cwl/debuginfo.rb
@@ -69,8 +69,8 @@ module CWLlog
               cwl_file: get_tool_cwl_file_path(step),
               container_id: get_container_id(step),
               tool_status: get_tool_status(step),
-              input_files: input_object(step),
-              output_files: output_object(step),
+              inputs: input_object(step),
+              outputs: output_object(step),
             }
           end
           step_info


### PR DESCRIPTION
This request renames field names for input and output parameters.
- For workflow: `input_jobfile` -> `inputs`
- For each step
  - `input_files` -> `inputs`
  - `output_files` -> `outputs`

Here are rationales for this change.
- For workflow, `input_jobfile` stores input parameters rather than input file name.
  - On the other hand, `cwl_file` stores the file name for the input CWL.
- For each step, `input_files` stores input parameters for the step but it may include other object such as integers, floating point numbers and strings.
  - `output_files` is not an appropriate name for the same reason.

Here are other candidates for field names:
- `input_object`, `output_object`
  - They are a little bit long names. IMO `inputs` and `outputs` are enough.
- `input`, `output`
  - It is a matter whether we treat it as an input *object* (singular) or input *parameters* (plural).
  - In this request, I choose `inputs` and `outputs` but `input` and `output` are also OK for me.
