### PR TITLE
Remove `--cidfile-dir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ cwltool --debug --leave-container --timestamps --compute-checksum --record-con
 ...
 $ docker ps -a --no-trunk > ps-file
 $ docker info > info-file
-$ generate_cwl_log --cidfile-dir result --docker-ps ./ps-file --docker-info ./info-file --job-conf inputs.yml --debug-output result/cwltool.log --output-dir result
+$ generate_cwl_log --docker-ps ./ps-file --docker-info ./info-file --job-conf inputs.yml --debug-output result/cwltool.log --output-dir result
 $ cat result/cwl_log.json | jq .
 {
   "workflow": {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A ruby script `generate_cwl_log` is for stand alone execution, but the generator
 For stand alone use, the script requires following information:
 
 - a path to the file containing debug output via `cwltool --debug`
-- a path to the directory containing cid files created by `cwltool --record-container-id`
 - a path to the job configuration file in yaml or json (optional)
 - output of `docker ps` as output or file (optional)
 - output of `docker info` as output or file (optional)

--- a/generate_cwl_log
+++ b/generate_cwl_log
@@ -13,7 +13,6 @@ if __FILE__ == $0
 
   opts = GetoptLong.new(
     ['--debug-output', GetoptLong::REQUIRED_ARGUMENT],
-    ['--cidfile-dir', GetoptLong::REQUIRED_ARGUMENT],
     ['--job-conf', GetoptLong::OPTIONAL_ARGUMENT],
     ['--docker-ps', GetoptLong::OPTIONAL_ARGUMENT],
     ['--docker-info', GetoptLong::OPTIONAL_ARGUMENT],
@@ -26,8 +25,6 @@ if __FILE__ == $0
       CWLlog::CWL::DebugInfo.load(arg) # --debug output with timestamps
     when '--job-conf'
       CWLlog::CWL::JobConf.load(arg) # job conf yaml or json
-    when '--cidfile-dir'
-      CWLlog::CWL::DebugInfo.cidfile_dir(arg) # --debug output with timestamps
     when '--docker-ps'
       CWLlog::Docker.load_docker_ps(arg)
     when '--docker-info'

--- a/lib/cwllog/cwl/debuginfo.rb
+++ b/lib/cwllog/cwl/debuginfo.rb
@@ -10,10 +10,6 @@ module CWLlog
           @@timestamps = get_timestamps
         end
 
-        def cidfile_dir(cid_dir)
-          nil
-        end
-
         #
         # Methods for class variables
         #

--- a/lib/cwllog/cwl/debuginfo.rb
+++ b/lib/cwllog/cwl/debuginfo.rb
@@ -11,7 +11,7 @@ module CWLlog
         end
 
         def cidfile_dir(cid_dir)
-          @@cid_dir = cid_dir
+          nil
         end
 
         #
@@ -77,7 +77,7 @@ module CWLlog
         end
 
         def get_container_id(step_name)
-          cid_path = File.join(@@cid_dir, get_cid_file_name(step_name))
+          cid_path = get_cid_file_name(step_name)
           if File.exist?(cid_path)
             open(cid_path).read
           end
@@ -86,7 +86,7 @@ module CWLlog
         def get_cid_file_name(step_name)
           ev = @@events.select{|str| str =~ /job #{step_name}.*--cidfile/m }.first
           line = ev.split("\n").select{|line| line =~ /--cidfile/ }.first
-          File.basename(line.split("=").last.delete("\s\\"))
+          line.split("=").last.delete("\s\\")
         end
 
         def get_tool_status(step_name)


### PR DESCRIPTION
This removes `--cidfile-dir` option because it can be inferred from the log file of `cwltool`.
It makes easier to run `cwl_log_generator`.

Note: It breaks [cwl-metrics](https://github.com/inutano/cwl-metrics). To merge this request, cwl-metrics also has to be fixed.
