### PR TITLE
Fix code block and link to `cwltool`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CWL Log Generator
 
-CWL Log Generator is one component of the [CWL-metrics](https://github.com/inutano/cwl-metrics) system for resource usage metrics collection of [Common Workflow Language (CWL)](https://www.commonwl.org) runs. CWL Log Generator generate JSON format log file by analyzing outputs from `[cwltool](https://github.com/common-workflow-language/cwltool/)` including debug output, docker container status, and platform information.
+CWL Log Generator is one component of the [CWL-metrics](https://github.com/inutano/cwl-metrics) system for resource usage metrics collection of [Common Workflow Language (CWL)](https://www.commonwl.org) runs. CWL Log Generator generate JSON format log file by analyzing outputs from [`cwltool`](https://github.com/common-workflow-language/cwltool/) including debug output, docker container status, and platform information.
 
 ## Usage
 


### PR DESCRIPTION
This request fixes a link block to cwltool. Currently the link to `cwltool` are shown in code block directly but it is not intended.