### PR TITLE
Add black-box test using conformance test 53

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+notifications:
+  email: false
+
+os:
+  - linux
+
+language: ruby
+rvm:
+  - 2.5.1
+
+services:
+  - docker
+
+install:
+  - pip install --user cwltool==1.0.20180820141117
+
+script:
+  - cd test/conformance-53 && make

--- a/test/compare_json.rb
+++ b/test/compare_json.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+require 'json'
+require 'optparse'
+
+class ComparisonError < StandardError
+  def initialize(msg = nil)
+    super(msg)
+  end
+end
+
+#
+# Check whether `actual` almost equals to `expected`.
+# If `actual` has different structures or values, fail with exception.
+#
+def must_almost_equals(expected, actual)
+  case expected
+  when nil
+    true
+  when Array
+    unless actual.instance_of?(Array)
+      raise ComparisonError, "Inconsistent type: expected type of #{expected}: Array, actual type of #{actual}: #{actual.class}"
+    end
+    unless expected.size == actual.size
+      raise ComparisonError, "Different size of arrays: expected size of #{expected}: #{expected.size}, actual size of #{actual}: #{actual.size}"
+    end
+
+    expected.to_enum.with_index.each do |e, i|
+      must_almost_equals(e, actual[i])
+    rescue ComparisonError => e
+      raise ComparisonError, "Different value of #{i}-th element of array"
+    end
+  when Hash
+    # Note: It is OK when `actual` has additional entries.
+    unless actual.instance_of?(Hash)
+      raise ComparisonError, "Incensistent type: expected type of #{expected}: Hash, actual type of #{actual}: #{actual.class}"
+    end
+
+    expected.each do |k, v|
+      unless actual.include?(k)
+        raise ComparisonError, "Missing key `#{k}` in actual: #{actual}"
+      end
+      must_almost_equals(v, actual[k])
+    rescue ComparisonError => e
+      if not e.cause.nil? and e.cause.message.match(/^Missing key `#{k}`/)
+        raise e
+      end
+      raise ComparisonError, "Different value for `#{k}`"
+    end
+  else
+    unless expected == actual
+      raise ComparisonError, "Comparison failed: #{expected} == #{actual}"
+    end
+  end
+end
+
+
+if $0 == __FILE__
+  opt = OptionParser.new
+  opt.banner = "Usage: #{$0} expected.json actual.json"
+  opt.parse!(ARGV)
+  unless ARGV.length == 2
+    puts opt.help
+    exit
+  end
+
+  exp, act = ARGV
+  unless File.exist? exp
+    warn "No such file: #{exp}"
+    exit 1
+  end
+  unless File.exist? act
+    warn "No such file: #{act}"
+    exit 1
+  end
+
+  expected = JSON.load(open(exp))
+  actual = JSON.load(open(act))
+
+  begin
+    must_almost_equals(expected, actual)
+  rescue ComparisonError => e
+    indent = 2
+    cur_indent = 0
+    until e.nil?
+      warn ' '*cur_indent+e.to_s
+      cur_indent += indent
+      e = e.cause
+    end
+    exit 1
+  end
+end

--- a/test/conformance-53/Makefile
+++ b/test/conformance-53/Makefile
@@ -1,0 +1,20 @@
+TMPDIR=${PWD}/tmp
+CWL=cwl/revsort.cwl
+JOB=cwl/revsort-job.json
+
+all: test
+
+test: cwl_log.json
+	../compare_json.rb expected.json cwl_log.json && echo ok.
+
+cwl_log.json: cwltool.log
+	../../generate_cwl_log --docker-ps ${TMPDIR}/ps-file --docker-info ${TMPDIR}/info-file --debug-output cwltool.log --output-dir .
+
+cwltool.log:
+	mkdir ${TMPDIR}
+	cwltool --debug --leave-container --timestamps --compute-checksum --record-container-id --cidfile-dir ${TMPDIR} --outdir ${TMPDIR} ${CWL} ${JOB} > /dev/null 2> cwltool.log
+	docker info > ${TMPDIR}/info-file
+	docker ps -a --no-trunc > ${TMPDIR}/ps-file
+
+clean:
+	rm -rf ${TMPDIR} cwl_log.json cwltool.log

--- a/test/conformance-53/cwl/revsort-job.json
+++ b/test/conformance-53/cwl/revsort-job.json
@@ -1,0 +1,6 @@
+{
+  "input": {
+    "class": "File",
+    "location": "whale.txt"
+  }
+}

--- a/test/conformance-53/cwl/revsort.cwl
+++ b/test/conformance-53/cwl/revsort.cwl
@@ -1,0 +1,65 @@
+#
+# This is a two-step workflow which uses "revtool" and "sorttool" defined above.
+#
+class: Workflow
+doc: "Reverse the lines in a document, then sort those lines."
+cwlVersion: v1.0
+
+# Requirements & hints specify prerequisites and extensions to the workflow.
+# In this example, DockerRequirement specifies a default Docker container
+# in which the command line tools will execute.
+hints:
+  - class: DockerRequirement
+    dockerPull: debian:stretch-slim
+
+
+# The inputs array defines the structure of the input object that describes
+# the inputs to the workflow.
+#
+# The "reverse_sort" input parameter demonstrates the "default" field.  If the
+# field "reverse_sort" is not provided in the input object, the default value will
+# be used.
+inputs:
+  input:
+    type: File
+    doc: "The input file to be processed."
+  reverse_sort:
+    type: boolean
+    default: true
+    doc: "If true, reverse (decending) sort"
+
+# The "outputs" array defines the structure of the output object that describes
+# the outputs of the workflow.
+#
+# Each output field must be connected to the output of one of the workflow
+# steps using the "connect" field.  Here, the parameter "#output" of the
+# workflow comes from the "#sorted" output of the "sort" step.
+outputs:
+  output:
+    type: File
+    outputSource: sorted/output
+    doc: "The output with the lines reversed and sorted."
+
+# The "steps" array lists the executable steps that make up the workflow.
+# The tool to execute each step is listed in the "run" field.
+#
+# In the first step, the "inputs" field of the step connects the upstream
+# parameter "#input" of the workflow to the input parameter of the tool
+# "revtool.cwl#input"
+#
+# In the second step, the "inputs" field of the step connects the output
+# parameter "#reversed" from the first step to the input parameter of the
+# tool "sorttool.cwl#input".
+steps:
+  rev:
+    in:
+      input: input
+    out: [output]
+    run: revtool.cwl
+
+  sorted:
+    in:
+      input: rev/output
+      reverse: reverse_sort
+    out: [output]
+    run: sorttool.cwl

--- a/test/conformance-53/cwl/revtool.cwl
+++ b/test/conformance-53/cwl/revtool.cwl
@@ -1,0 +1,37 @@
+#
+# Simplest example command line program wrapper for the Unix tool "rev".
+#
+class: CommandLineTool
+cwlVersion: v1.0
+doc: "Reverse each line using the `rev` command"
+
+# The "inputs" array defines the structure of the input object that describes
+# the inputs to the underlying program.  Here, there is one input field
+# defined that will be called "input" and will contain a "File" object.
+#
+# The input binding indicates that the input value should be turned into a
+# command line argument.  In this example inputBinding is an empty object,
+# which indicates that the file name should be added to the command line at
+# a default location.
+inputs:
+  input:
+    type: File
+    inputBinding: {}
+
+# The "outputs" array defines the structure of the output object that
+# describes the outputs of the underlying program.  Here, there is one
+# output field defined that will be called "output", must be a "File" type,
+# and after the program executes, the output value will be the file
+# output.txt in the designated output directory.
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: output.txt
+
+# The actual program to execute.
+baseCommand: rev
+
+# Specify that the standard output stream must be redirected to a file called
+# output.txt in the designated output directory.
+stdout: output.txt

--- a/test/conformance-53/cwl/sorttool.cwl
+++ b/test/conformance-53/cwl/sorttool.cwl
@@ -1,0 +1,35 @@
+# Example command line program wrapper for the Unix tool "sort"
+# demonstrating command line flags.
+class: CommandLineTool
+doc: "Sort lines using the `sort` command"
+cwlVersion: v1.0
+
+# This example is similar to the previous one, with an additional input
+# parameter called "reverse".  It is a boolean parameter, which is
+# intepreted as a command line flag.  The value of "prefix" is used for
+# flag to put on the command line if "reverse" is true, if "reverse" is
+# false, no flag is added.
+#
+# This example also introduced the "position" field.  This indicates the
+# sorting order of items on the command line.  Lower numbers are placed
+# before higher numbers.  Here, the "--reverse" flag (if present) will be
+# added to the command line before the input file path.
+inputs:
+  - id: reverse
+    type: boolean
+    inputBinding:
+      position: 1
+      prefix: "--reverse"
+  - id: input
+    type: File
+    inputBinding:
+      position: 2
+
+outputs:
+  - id: output
+    type: File
+    outputBinding:
+      glob: output.txt
+
+baseCommand: sort
+stdout: output.txt

--- a/test/conformance-53/cwl/whale.txt
+++ b/test/conformance-53/cwl/whale.txt
@@ -1,0 +1,16 @@
+Call me Ishmael. Some years ago--never mind how long precisely--having
+little or no money in my purse, and nothing particular to interest me on
+shore, I thought I would sail about a little and see the watery part of
+the world. It is a way I have of driving off the spleen and regulating
+the circulation. Whenever I find myself growing grim about the mouth;
+whenever it is a damp, drizzly November in my soul; whenever I find
+myself involuntarily pausing before coffin warehouses, and bringing up
+the rear of every funeral I meet; and especially whenever my hypos get
+such an upper hand of me, that it requires a strong moral principle to
+prevent me from deliberately stepping into the street, and methodically
+knocking people's hats off--then, I account it high time to get to sea
+as soon as I can. This is my substitute for pistol and ball. With a
+philosophical flourish Cato throws himself upon his sword; I quietly
+take to the ship. There is nothing surprising in this. If they but knew
+it, almost all men in their degree, some time or other, cherish very
+nearly the same feelings towards the ocean with me.

--- a/test/conformance-53/expected.json
+++ b/test/conformance-53/expected.json
@@ -1,0 +1,134 @@
+{
+  "workflow": {
+    "start_date": null,
+    "end_date": null,
+    "cwl_file": "revsort.cwl",
+    "genome_version": null,
+    "inputs": {
+      "input": {
+        "class": "File",
+        "location": null,
+        "size": 1111,
+        "basename": "whale.txt",
+        "nameroot": "whale",
+        "nameext": ".txt"
+      },
+      "reverse_sort": true
+    },
+    "outputs": {
+      "output": {
+        "location": null,
+        "basename": "output.txt",
+        "nameroot": "output",
+        "nameext": ".txt",
+        "class": "File",
+        "checksum": "sha1$b9214658cc453331b62c2282b772a5c063dbd284",
+        "size": 1111
+      }
+    }
+  },
+  "steps": {
+    "rev": {
+      "stepname": "rev",
+      "start_date": null,
+      "end_date": null,
+      "cwl_file": null,
+      "container_id": null,
+      "tool_status": "success",
+      "inputs": {
+        "input": {
+          "class": "File",
+          "location": null,
+          "size": 1111,
+          "basename": "whale.txt",
+          "nameroot": "whale",
+          "nameext": ".txt"
+        }
+      },
+      "outputs": {
+        "output": {
+          "location": null,
+          "basename": "output.txt",
+          "nameroot": "output",
+          "nameext": ".txt",
+          "class": "File",
+          "checksum": "sha1$97fe1b50b4582cebc7d853796ebd62e3e163aa3f",
+          "size": 1111
+        }
+      },
+      "docker_image": "debian:stretch-slim",
+      "docker_cmd": null,
+      "docker_status": null,
+      "docker_inspect": {
+        "start_time": null,
+        "end_time": null,
+        "exit_code": 0
+      },
+      "docker": {
+        "running_containers": null,
+        "server_version": null,
+        "storage_driver": null,
+        "number_of_cpu": null,
+        "total_memory": null
+      },
+      "platform": {
+        "hostname": null,
+        "ncpu_cores": null,
+        "total_memory": null,
+        "disk_size": null
+      }
+    },
+    "sorted": {
+      "stepname": "sorted",
+      "start_date": null,
+      "end_date": null,
+      "cwl_file": null,
+      "container_id": null,
+      "tool_status": "success",
+      "inputs": {
+        "input": {
+          "location": null,
+          "basename": "output.txt",
+          "nameroot": "output",
+          "nameext": ".txt",
+          "class": "File",
+          "checksum": "sha1$97fe1b50b4582cebc7d853796ebd62e3e163aa3f",
+          "size": 1111
+        },
+        "reverse": true
+      },
+      "outputs": {
+        "output": {
+          "location": null,
+          "basename": "output.txt",
+          "nameroot": "output",
+          "nameext": ".txt",
+          "class": "File",
+          "checksum": "sha1$b9214658cc453331b62c2282b772a5c063dbd284",
+          "size": 1111
+        }
+      },
+      "docker_image": "debian:stretch-slim",
+      "docker_cmd": null,
+      "docker_status": null,
+      "docker_inspect": {
+        "start_time": null,
+        "end_time": null,
+        "exit_code": 0
+      },
+      "docker": {
+        "running_containers": null,
+        "server_version": null,
+        "storage_driver": null,
+        "number_of_cpu": null,
+        "total_memory": null
+      },
+      "platform": {
+        "hostname": null,
+        "ncpu_cores": null,
+        "total_memory": null,
+        "disk_size": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
This request adds a black-box test that checks the structure and values of resulted `cwl_log.json` by using conformance test 53 (consists of [revsort.cwl](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/revsort.cwl), [revtool.cwl](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/revtool.cwl), [sorttool.cwl](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/sorttool.cwl), [whale.txt](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/whale.txt), and [revsort-job.json](https://github.com/common-workflow-language/common-workflow-language/blob/master/v1.0/v1.0/revsort-job.json)).
I also adds `.travis.yml` for Travis CI.

We can run the test by using `make` in `test/conformance-53`. It runs `cwltool` with appropriate options, generates the file for `docker ps` and `docker info`, and then runs `generate_cwl_log` to generate `cwl_log.json`. Finally it compares `cwl_log.json` with `expected.json`, that is an expected value of the output, by using `compare_json.rb`.

Obviously `cwl_log.json` contains fragile values for test (e.g. `start_date`, `end_date`, `container_id` etc.).
Therefore `compare_json.rb` must check the existence of such keys but must ignore their values.
To do that, `expected.json` uses `null` that indicates a fragile value to be ignored.

More precisely, `compare_json.rb` checks whether the actual value in `cwl_log.json` almost equals to the expected value in `expected.json` using the following rules:

- If the expected value is an array, it checks:
  - the actual value must be an array,
  - the array size of actual value must be same as that of the expected array, and
  - each element of the expected array must almost equal to the corresponding element of the actual array (checked recursively).
- If the expected value is a hash, it checks:
  - the actual value must be a hash, and
  - the all keys in the expected hash must exists in the actual hash, and
  - each value in the expected hash must almost equal to the corresponding value of the actual hash (checked recursively).
- if the expected value is `null`, then it always succeeds.
- Otherwise the actual value must be the same as the expected value.

## Running example

- The case in success
```console
$ cd test/conformance-53 && make
mkdir /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp
cwltool --debug --leave-container --timestamps --compute-checksum --record-container-id --cidfile-dir /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp --outdir /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp cwl/revsort.cwl cwl/revsort-job.json > /dev/null 2> cwltool.log
docker info > /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/info-file
docker ps -a --no-trunc > /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/ps-file
../../generate_cwl_log --docker-ps /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/ps-file --docker-info /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/info-file --debug-output cwltool.log --output-dir .
../compare_json.rb expected.json cwl_log.json && echo ok.
ok.
$ echo $?
0
```

- The case in failure (the value of `steps.sorted.platform.disk_size` in `expected.json` is different from the value in `cwl_log.json`)
```console
$ cd test/conformance-53 && make
mkdir /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp
cwltool --debug --leave-container --timestamps --compute-checksum --record-container-id --cidfile-dir /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp --outdir /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp cwl/revsort.cwl cwl/revsort-job.json > /dev/null 2> cwltool.log
docker info > /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/info-file
docker ps -a --no-trunc > /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/ps-file
../../generate_cwl_log --docker-ps /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/ps-file --docker-info /Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-53/tmp/info-file --debug-output cwltool.log --output-dir .
../compare_json.rb expected.json cwl_log.json && echo ok.
Different value for `steps`
  Different value for `sorted`
    Different value for `platform`
      Different value for `disk_size`
        Comparison failed: 1 == 976265452
make: *** [test] Error 1
$ echo $?
2
```