### PR TITLE
Add `cwl-metrics-version` field

### DIFF
--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -3,6 +3,8 @@ require 'cwllog/env'
 require 'cwllog/docker'
 require 'cwllog/cwl'
 
+Version = "0.1.18"
+
 module CWLlog
   class << self
     def generate
@@ -24,6 +26,7 @@ module CWLlog
     def cwl_log
       parse_logs
       {
+        cwl_metrics_version: Version,
         workflow: {
           start_date: @@logs[:cwl][:debug_info][:workflow][:start_date],
           end_date: @@logs[:cwl][:debug_info][:workflow][:end_date],


### PR DESCRIPTION
 This request adds a version field that makes the output file more robust from breaking changes in the future.
By adding this field, `cwl-metrics fetch` may absorb the gap between the older version of collected metrics and newer version of collected metrics.

It simply adds `cwl-metrics-version` that indicates the version of `cwl-log-generator`.
I tentatively use `0.1.18` for this field but it will be fixed for future release.

Note: This is not the request to absorb the gaps or to add an abstraction layer in `cwl-metrics fetch`. It is just for a preparation of future breaking changes.