### PR TITLE
Add metrics generator field

### DIFF
--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -4,7 +4,7 @@ require 'cwllog/docker'
 require 'cwllog/cwl'
 
 FormatVersion = "0.1.18"
-GeneratorVersion = "0.1.18"
+GeneratorVersion = "0.1.22"
 
 module CWLlog
   class << self

--- a/lib/cwllog.rb
+++ b/lib/cwllog.rb
@@ -3,7 +3,8 @@ require 'cwllog/env'
 require 'cwllog/docker'
 require 'cwllog/cwl'
 
-Version = "0.1.18"
+FormatVersion = "0.1.18"
+GeneratorVersion = "0.1.18"
 
 module CWLlog
   class << self
@@ -26,7 +27,11 @@ module CWLlog
     def cwl_log
       parse_logs
       {
-        cwl_metrics_version: Version,
+        cwl_metrics_version: FormatVersion,
+        metrics_generator: {
+          name: "cwl-log-generator",
+          version: GeneratorVersion,
+        },
         workflow: {
           start_date: @@logs[:cwl][:debug_info][:workflow][:start_date],
           end_date: @@logs[:cwl][:debug_info][:workflow][:end_date],

--- a/test/conformance-53/expected.json
+++ b/test/conformance-53/expected.json
@@ -1,8 +1,8 @@
 {
   "cwl_metrics_version": "0.1.18",
   "metrics_generator": {
-    "name": "cwl-log-generator",
-    "version": "0.1.18"
+    "name": null,
+    "version": null
   },
   "workflow": {
     "start_date": null,

--- a/test/conformance-53/expected.json
+++ b/test/conformance-53/expected.json
@@ -1,4 +1,9 @@
 {
+  "cwl_metrics_version": "0.1.18",
+  "metrics_generator": {
+    "name": "cwl-log-generator",
+    "version": "0.1.18"
+  },
   "workflow": {
     "start_date": null,
     "end_date": null,


### PR DESCRIPTION
This request is for #19.

I rename `Version` to `FormatVersion` and introduce `GeneratorVersion` as a version of `cwl-log-generator`.

I also update the test for new fields.
It checks the existence of `metrics_generator.name` and `metrics_generator.version` fields but does not check their values.
The reason is to make `expected.json` applicable to check the validator of other log generators which are compatible with `cwl-log-generator`.
