### PR TITLE
Omit output object event for `cwl.output.json`

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -9,7 +9,11 @@ def generate(config)
     lines = open(config.debug_log).read.split(/\n\[/m)
     lines.shift(2)
     lines.pop(2)
-    events = lines.map{|l| CWLEvent.new(l) }
+    events = lines.map do |l|
+      CWLEvent.new(l)
+    rescue
+      nil
+    end.compact
 
     info = case events.first.tag.strip
            when 'workflow'


### PR DESCRIPTION
Currently `cwl-log-generator` does not work with `CommandLineTool` that refers `cwl.output.json`.
Here is an example of the error message:

```
#<RuntimeError: Invalid event: 2019-04-15 16:01:12] Raw output from /private/tmp/docker_tmpf1g9cid5/cwl.output.json: {
    "args": [
        "bwa",
        "mem",
        "-t",
        "2",
        "-I",
        "1,2,3,4",
        "-m",
        "3",
        "chr20.fa",
        "example_human_Illumina.pe_1.fastq",
        "example_human_Illumina.pe_2.fastq"
    ]
}>
/Users/tanjo/repos/cwl-metrics/cwl-log-generator/lib/cwlevent.rb:11:in `initialize'
/Users/tanjo/repos/cwl-metrics/cwl-log-generator/lib/generator.rb:12:in `new'
/Users/tanjo/repos/cwl-metrics/cwl-log-generator/lib/generator.rb:12:in `block in generate'
/Users/tanjo/repos/cwl-metrics/cwl-log-generator/lib/generator.rb:12:in `map'
/Users/tanjo/repos/cwl-metrics/cwl-log-generator/lib/generator.rb:12:in `generate'
../../generate_cwl_log:47:in `<main>'
``` 

This is the corresponding log message: 
```
[2019-04-15 15:50:54] Raw output from /private/tmp/docker_tmp0vajww3y/cwl.output.json: {
    "args": [
        "bwa",
        "mem",
        "-t",
        "2",
        "-I",
        "1,2,3,4",
        "-m",
        "3",
        "chr20.fa",
        "example_human_Illumina.pe_1.fastq",
        "example_human_Illumina.pe_2.fastq"
    ]
}
```

This request omit this message from generating `CWLEvent` object because it is not used to generate logs.

Note: This request is not enough to make cwl-log-generator workable with CommandLineTools because there is another minor issue. I will send a PR for that.