### PR TITLE
Fix generating `JobInfo` object in `generator.rb`

### DIFF
--- a/lib/generator.rb
+++ b/lib/generator.rb
@@ -11,11 +11,11 @@ def generate(config)
     lines.pop(2)
     events = lines.map{|l| CWLEvent.new(l) }
 
-    info = case events.first.tag.strip
+    info = case events.first.tag.split.first
            when 'workflow'
              WorkflowInfo.new(events, config)
            when 'job'
-             JobInfo.new(events, config)
+             JobInfo.new(nil, events, config)
            else
              raise "Invalid event tag: #{events.first.tag.strip}"
            end

--- a/lib/jobinfo.rb
+++ b/lib/jobinfo.rb
@@ -24,8 +24,7 @@ class JobInfo
   end
 
   def to_h
-    {
-      stepname: @stepname,
+    ret = {
       start_date: @start_date,
       end_date: @end_date,
       cwl_file: @cwl_file,
@@ -38,6 +37,8 @@ class JobInfo
       },
       platform: @platform,
     }
+    ret[:stepname] = @stepname if @stepname
+    ret
   end
 end
 


### PR DESCRIPTION
`generator.rb` call the constructor of `JobInfo` but it does not work because the number of arguments for it is wrong. This request fixes it.

It also fixes how distinguish from Workflows and CommandLineTools to handle this kind of messages in CommandLineTool.
```
[2019-04-15 15:50:52] [job bwa-mem-tool.cwl] initializing from file:///Users/tom-tan/repos/cwl-metrics/cwl-log-generator/test/conformance-1/cwl/bwa-mem-tool.cwl
```

Note: By merging #24 and this request, cwl-log-generator can support CommandLineTools.